### PR TITLE
Fix for issue 273 of lichobile https://github.com/veloce/lichobile/issues/273

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -10,6 +10,7 @@ module.exports = function(cfg) {
     lastMove: null, // squares part of the last move ["c3", "c4"] | null
     selected: null, // square currently selected "a1" | null
     coordinates: true, // include coords attributes
+    symmetricCoordinates: false, // include symmetric coords attributes for otb
     render: null, // function that rerenders the board
     renderRAF: null, // function that rerenders the board using requestAnimationFrame
     element: null, // DOM element of the board, required for drag piece centering

--- a/src/view.js
+++ b/src/view.js
@@ -172,8 +172,14 @@ function renderSquare(ctrl, pos, asWhite) {
     }
   };
   if (ctrl.data.coordinates) {
-    if (pos[1] === (asWhite ? 1 : 8)) attrs['data-coord-x'] = file;
-    if (pos[0] === (asWhite ? 8 : 1)) attrs['data-coord-y'] = rank;
+    // Coordinates from white's perspective
+    if (pos[1] === (asWhite ? 1 : 8)) attrs['data-coord-white-x'] = file;
+    if (pos[0] === (asWhite ? 8 : 1)) attrs['data-coord-white-y'] = rank;
+    // Coordinates from black's perspectice
+    if (ctrl.data.symmetricCoordinates) {
+      if (pos[1] === (asWhite ? 8 : 1)) attrs['data-coord-black-x'] = file;
+      if (pos[0] === (asWhite ? 1 : 8)) attrs['data-coord-black-y'] = rank;
+    }
   }
   var children = [];
   if (piece) {


### PR DESCRIPTION
Fix for issue 273 of lichobile https://github.com/veloce/lichobile/issues/273
This requires another pull on the lichobile source (https://github.com/veloce/lichobile/pull/403)

In order to not mess with the surrounding layout and keep maximum board space, coordinates are inside the squares.

ISSUE:
The board is not updated with `m.redraw` but getting out of OTB and in again does the trick.
